### PR TITLE
[bugfix] fix memory leak

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -132,6 +132,7 @@ int main(int c, char* v[])
     double translation[9] = {1, 0, (double) x, 0, 1, (double) y, 0, 0, 1};
     double hom_compensated[9];
     matrix_33_product(hom_compensated, hom, translation);
+    free(hom);
     if (verbose) time.get_time("Compute needed ROI");
 
 	// create the output image
@@ -151,6 +152,7 @@ int main(int c, char* v[])
 
 		// copy the ROI data to marc's image struct
 		Image roi(roi_data, w, h, 1);
+		free(roi_data);
 		if (verbose) time.get_time("Read needed ROI");
 
 		// call the mapping function


### PR DESCRIPTION
Valgrind detects a memory leak in the implementation of `homography` as of commit 8a5982b. 
```
valgrind --leak-check=full ./bin/homography tests/data/input_pair/img_01.tif -h "0.2088266449652911 -0.978434137513051 839.3450201412996 0.978434137513051 0.2088266449652911 -246.1784431096032 0.0 0.0 1.0" tests/testoutput/output_pair/tiles/row_0000500_height_350/col_0000150_width_350/pair_1/rectified_ref.tif 493 425
```
The output of this command, run from an `s2p` clone root directory, gives

```
==20169== HEAP SUMMARY:
==20169==     in use at exit: 2,808,040 bytes in 3,858 blocks
==20169==   total heap usage: 7,888 allocs, 4,030 frees, 9,789,417 bytes allocated
==20169==
==20169== 72 bytes in 1 blocks are definitely lost in loss record 2,911 of 3,571
==20169==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==20169==    by 0x10B9BC: alloc_parse_doubles(int, char const*, int*) (in /home/carlo/3d/s2p/src/bin/homography)
==20169==    by 0x10AB4D: main (in /home/carlo/3d/s2p/src/bin/homography)
==20169==
==20169== 1,187,472 bytes in 1 blocks are possibly lost in loss record 3,571 of 3,571
==20169==    at 0x4C2FB0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==20169==    by 0x5BB53AF: CPLMalloc (in /usr/lib/libgdal.so.26.0.2)
==20169==    by 0x10B0BF: main (in /home/carlo/3d/s2p/src/bin/homography)
==20169==
==20169== LEAK SUMMARY:
==20169==    definitely lost: 72 bytes in 1 blocks
==20169==    indirectly lost: 0 bytes in 0 blocks
==20169==      possibly lost: 1,187,472 bytes in 1 blocks
==20169==    still reachable: 1,620,496 bytes in 3,856 blocks
==20169==         suppressed: 0 bytes in 0 blocks
==20169== Reachable blocks (those to which a pointer was found) are not shown.
==20169== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==20169==
==20169== For counts of detected and suppressed errors, rerun with: -v
==20169== ERROR SUMMARY: 2 errors from 2 contexts (suppressed: 0 from 0)
```

With this fix, valgrind doesn't report leaks anymore:
```
==20623== HEAP SUMMARY:
==20623==     in use at exit: 1,620,496 bytes in 3,856 blocks
==20623==   total heap usage: 7,888 allocs, 4,032 frees, 9,789,417 bytes allocated
==20623==
==20623== LEAK SUMMARY:
==20623==    definitely lost: 0 bytes in 0 blocks
==20623==    indirectly lost: 0 bytes in 0 blocks
==20623==      possibly lost: 0 bytes in 0 blocks
==20623==    still reachable: 1,620,496 bytes in 3,856 blocks
==20623==         suppressed: 0 bytes in 0 blocks
==20623== Reachable blocks (those to which a pointer was found) are not shown.
==20623== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==20623==
==20623== For counts of detected and suppressed errors, rerun with: -v
==20623== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```